### PR TITLE
Fixing the path to find Bower files in Gradle multi-project builds.

### DIFF
--- a/src/main/groovy/com/craigburke/gradle/BowerInstallerPlugin.groovy
+++ b/src/main/groovy/com/craigburke/gradle/BowerInstallerPlugin.groovy
@@ -63,7 +63,7 @@ class BowerInstallerPlugin implements Plugin<Project> {
                 description: 'Installs bower dependencies') {
             doFirst {
                 FileTree bowerRoot = project.fileTree('bower_components')
-                def bowerJson = BowerJson.generateFinal(bowerConfig, project.rootDir, bowerRoot)
+                def bowerJson = BowerJson.generateFinal(bowerConfig, project.projectDir, bowerRoot)
                 
                 // Make sure containing folder exists
                 bowerJson.content.install.sources.each { String moduleName, config ->


### PR DESCRIPTION
When applying the plugin in multi-project builds the path used in bower.json to install the assets is based on the project root dir. If the plugin is applied to a project that is not a root the Bower installer cannot find the assets and the build fails.

To fix this we need to use the current project dir so the plugin can write the correct paths into bower.json.
